### PR TITLE
Leverage reversed lexicographic order junit test execution rule to en…

### DIFF
--- a/9131071/QuestionTest.java
+++ b/9131071/QuestionTest.java
@@ -3,14 +3,14 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class QuestionTest {
-    @Before
-    public void setUpClientStub() {
-        // Client stub setup
+    @Before  // Will execute second (reverse lex order)
+    public void z_setUpObjectUnderTest() {
+        // Object under test setup
     }
 
-    @Before
-    public void setUpObjectUnderTest() {
-        // Object under test setup
+    @Before  // Will execute first (reverse lex order)
+    public void a_setUpClientStub() {
+        // Client stub setup
     }
 
     @Test


### PR DESCRIPTION
…force setup right execution order

- Split Fixture (Correctly -- question's split fixture broke execution order)
- Rename Test (Interesting motivation to rename)
 